### PR TITLE
consistent positional args; minor fix for plane_seed docs

### DIFF
--- a/R/planes.R
+++ b/R/planes.R
@@ -199,12 +199,11 @@ plane_taper <- function(location, input, seed) {
 #'
 #' This function evaluates whether consecutive values in observations or forecasts are repeated a k number of times. This function takes in a [forecast][to_signal()] object that is either from an observed dataset or forecast dataset.
 #'
-#'
-#' @param input Input signal data to be scored; object must be one of [forecast][to_signal()]
 #' @param location Character vector with location code; the location must appear in input and seed
+#' @param input Input signal data to be scored; object must be one of [forecast][to_signal()]
+#' @param seed Prepared [seed][plane_seed()]
 #' @param tolerance Integer value for the number of allowed repeats before flag is raised. Default is `NULL` and allowed repeats will be determined from seed.
 #' @param prepend Integer value for the number of values from seed to add before the evaluated signal. Default is `NULL` and the number of values will be determined from seed.
-#' @param seed Prepared [seed][plane_seed()]
 #'
 #' @return
 #'
@@ -215,7 +214,7 @@ plane_taper <- function(location, input, seed) {
 #'
 #' @export
 #'
-plane_repeat <- function(input, location, tolerance = NULL, prepend = NULL, seed){
+plane_repeat <- function(location, input, seed, tolerance = NULL, prepend = NULL){
 
   ## double check that location is in seed before proceeding
   if(!location %in% names(seed)) {

--- a/R/seed.R
+++ b/R/seed.R
@@ -97,7 +97,7 @@ seed_engine <- function(input, location, cut_date=NULL) {
 #' @param input Input signal data used for seeding; must be an observed signal object
 #' @param cut_date Maximum date (inclusive) for which seeding should be performed; default is `NULL` and the entire input will be used for seeding
 #'
-#'  @return A named `list` of length *n*, where multiple elements corresponding to seed characteristics and metadata for each of the *n* locations are nested in independent lists.
+#' @return A named `list` of length *n*, where multiple elements corresponding to seed characteristics and metadata for each of the *n* locations are nested in independent lists.
 #' @export
 #'
 plane_seed <- function(input, cut_date=NULL) {

--- a/man/plane_repeat.Rd
+++ b/man/plane_repeat.Rd
@@ -4,18 +4,18 @@
 \alias{plane_repeat}
 \title{Repeat component}
 \usage{
-plane_repeat(input, location, tolerance = NULL, prepend = NULL, seed)
+plane_repeat(location, input, seed, tolerance = NULL, prepend = NULL)
 }
 \arguments{
+\item{location}{Character vector with location code; the location must appear in input and seed}
+
 \item{input}{Input signal data to be scored; object must be one of \link[=to_signal]{forecast}}
 
-\item{location}{Character vector with location code; the location must appear in input and seed}
+\item{seed}{Prepared \link[=plane_seed]{seed}}
 
 \item{tolerance}{Integer value for the number of allowed repeats before flag is raised. Default is \code{NULL} and allowed repeats will be determined from seed.}
 
 \item{prepend}{Integer value for the number of values from seed to add before the evaluated signal. Default is \code{NULL} and the number of values will be determined from seed.}
-
-\item{seed}{Prepared \link[=plane_seed]{seed}}
 }
 \value{
 A \code{list} with the following values:

--- a/man/plane_seed.Rd
+++ b/man/plane_seed.Rd
@@ -9,9 +9,10 @@ plane_seed(input, cut_date = NULL)
 \arguments{
 \item{input}{Input signal data used for seeding; must be an observed signal object}
 
-\item{cut_date}{Maximum date (inclusive) for which seeding should be performed; default is \code{NULL} and the entire input will be used for seeding
-
-@return A named \code{list} of length \emph{n}, where multiple elements corresponding to seed characteristics and metadata for each of the \emph{n} locations are nested in independent lists.}
+\item{cut_date}{Maximum date (inclusive) for which seeding should be performed; default is \code{NULL} and the entire input will be used for seeding}
+}
+\value{
+A named \code{list} of length \emph{n}, where multiple elements corresponding to seed characteristics and metadata for each of the \emph{n} locations are nested in independent lists.
 }
 \description{
 This function wraps the \link{seed_engine} to operate across all locations in the input signal.


### PR DESCRIPTION
this PR fixes the positional args (#48 ) and also takes care of a minor bug with an extra space in the `@return` tag in `plane_seed()` docs