### PR TITLE
85 vignette describing how individual planes components work

### DIFF
--- a/man/rplanes-package.Rd
+++ b/man/rplanes-package.Rd
@@ -18,7 +18,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: VP Nagraj \email{pnagraj@signaturescience.com} (\href{https://orcid.org/0000-0003-0060-566X}{ORCID})
+\strong{Maintainer}: VP Nagraj \email{nagraj@nagraj.net} (\href{https://orcid.org/0000-0003-0060-566X}{ORCID})
 
 Authors:
 \itemize{

--- a/vignettes/individual-components.Rmd
+++ b/vignettes/individual-components.Rmd
@@ -1,6 +1,9 @@
 ---
-title: "individual-components"
-output: rmarkdown::html_vignette
+title: "Individual Components"
+output: 
+  rmarkdown::html_vignette:
+    toc: TRUE
+    number_sections: true
 vignette: >
   %\VignetteIndexEntry{individual-components}
   %\VignetteEngine{knitr::rmarkdown}
@@ -10,21 +13,17 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  echo=TRUE,
+  comment = "#>",
+  warning=FALSE,
+  message=FALSE,
+  fig.width = 7,
+  fig.height = 5
 )
 ```
 
-```{r setup}
-library(rplanes)
-library(dplyr)
-library(purrr)
-library(ggplot2)
-```
-
-
-# Individual Components
-
-The rplanes package currently has a set of 5 components that each test for plausibility in different ways. All 5 components are then wrapped into `plane_score()` to produce an overall score based on the number of components that raised implausibility flags. You can also run the components individually to look at certain aspects of your data. All components can be used to test forecast data, but some cannot be used on observed data. We will go through the components individually below using the same data that we have already read in and formatted in II.1. above. All 5 components use the following arguments, and some have additional arguments:
+# Overview
+The rplanes package currently has a set of 5 components that each test for plausibility in different ways. All 5 components are then wrapped into `plane_score()` to produce an overall score based on the number of components that raised implausibility flags. You can also run the components individually to look at certain aspects of your data. All components can be used to test forecast data, but some cannot be used on observed data. We will go through the components individually below. All 5 components use the following arguments, and some have additional arguments:
 
 * `location`: character vector with location code; the location must appear in input and seed. The location can be any character vector with unique names (e.g., FIPS codes, state abbreviations, county names, etc.)
 * `input`: input signal data to be scored; object must be one of signal (forecast or observed - created using `to_signal()`)
@@ -32,6 +31,91 @@ The rplanes package currently has a set of 5 components that each test for plaus
 
 Additionally, all components return an `indicator` field that tells us whether or not the data is plausible. If `indicator = TRUE`, the data is implausible and a flag is raised. If it is false, the data is plausible and no flag is raised.
 
+# Load and Format Data
+First, let's read in and format the data appropriately. For a more detailed discussion of these formatting functions, see the **Basic Usage** article.
+
+Several packages must be loaded prior to conducting the analysis:
+
+```{r message = FALSE}
+library(rplanes)
+library(dplyr)
+library(purrr)
+library(ggplot2)
+```
+
+#### Prepare observed data
+
+To motivate this example we will use incident flu hospitalization reported via [HHS Protect](https://healthdata.gov/Hospital/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/g62h-syeh). Note that the data here has been aggregated from daily to weekly resolution, and is provided in this format as internal `rplanes` package data. We select only the columns in which we're interested ("date", "location", and "flu.admits") and make sure that the date field is formatted as a date:
+
+```{r, eval=FALSE}
+hosp_all <-
+  read.csv(system.file("extdata/observed/hdgov_hosp_weekly.csv", package = "rplanes")) %>%
+  select(date, location, flu.admits) %>%
+  mutate(date = as.Date(date))
+
+head(hosp_all)
+```
+
+```{r, eval = TRUE, echo=FALSE}
+hosp_all <-
+  read.csv(system.file("extdata/observed/hdgov_hosp_weekly.csv", package = "rplanes")) %>%
+  select(date, location, flu.admits) %>%
+  mutate(date = as.Date(date))
+
+knitr::kable(head(hosp_all))
+```
+
+
+#### Convert observed data into a signal with `to_signal()`
+```{r}
+observed_signal <- to_signal(input = hosp_all, outcome = "flu.admits", type = "observed", resolution = "weeks", horizon = NULL)
+```
+
+#### Create a seed from the observed data via `plane_seed()`
+```{r}
+prepped_seed <- plane_seed(observed_signal, cut_date = "2022-10-29")
+```
+
+#### Prepare forecast data
+For this example, we use a forecast of incident weekly flu hospitalizations. This forecast is originally in the quantile format referenced above and is included in `rplanes` as example data:
+```{r, echo=TRUE, eval=FALSE}
+forecast_fp <- system.file("extdata/forecast/2022-10-31-SigSci-TSENS.csv", package = "rplanes")
+
+read.csv(forecast_fp) %>% 
+  head(.)
+```
+
+```{r, echo=FALSE, eval=TRUE}
+forecast_fp <- system.file("extdata/forecast/2022-10-31-SigSci-TSENS.csv", package = "rplanes")
+
+read.csv(forecast_fp) %>% 
+  head(.) %>%
+  knitr::kable(.)
+```
+
+We can use `read_forecast()` to load the data and convert to the required format:
+```{r, echo=TRUE, eval=FALSE}
+prepped_forecast <- read_forecast(forecast_fp)
+
+head(prepped_forecast)
+```
+
+```{r, echo=FALSE, eval=TRUE}
+prepped_forecast <- read_forecast(forecast_fp)
+
+knitr::kable(head(prepped_forecast))
+```
+
+#### Convert forecast data into a signal with `to_signal()`
+With the forecast formatted appropriately, we can convert it to a signal object:
+
+```{r}
+forecast_signal <- 
+  prepped_forecast  %>%
+  to_signal(., outcome = "flu.admits", type = "forecast", resolution = "weeks", horizon = 4)
+```
+
+#### Helper Function for Downstream Analysis
 Before we get into the component functions, let's write a function to retrieve the observed and forecast data for a specific location so that we can plot examples of flags of each component:
 ```{r}
 get_data <- function(Location) {
@@ -59,11 +143,11 @@ get_data <- function(Location) {
 
 
 
-## 1. Difference component, plane_diff():
-#### A. Description:
+# Difference component, plane_diff():
+### Description:
 This function implements the point-to-point difference plausibility component. Differences in evaluated signals are calculated from input values iteratively subtracted from the previous values (i.e., for each x at time point i, the difference will be calculated as xi - xi-1). The plausibility analysis uses the evaluated differences to compare against the maximum difference observed and recorded in the seed. This component can be used on either forecast data or observed data, and it only uses the three arguments listed above.
 
-#### B. An example where a flag is NOT raised and the data is plausible:
+### An example where a flag is NOT raised and the data is plausible:
 First, let's look at a location where the difference component does not raise a flag:
 ```{r}
 # Run plane_diff()
@@ -92,7 +176,7 @@ ggplot(data = diff_dat, mapping = aes(x = date, y = flu.admits)) +
 ```
 In this example at location 51, no flag was raised, because the difference between the last observed data point and the first forecast data point (black line, difference = 45) was not greater than the maximum difference between consecutive points within the observed dataset (in this case, that maximum difference is between the second to last observed and the last observed points and it equals 97).
 
-#### C. An example where a flag IS raised and the data is implausible:
+### An example where a flag IS raised and the data is implausible:
 Next, let's look at a location where a flag will be triggered by `plane_diff()`:
 ```{r}
 # Run plane_diff()
@@ -115,7 +199,7 @@ ggplot(data = diff_dat_flag, mapping = aes(x = date, y = flu.admits)) +
   ggtitle(paste("Difference Component where Flag Was Raised"))
 ```
 
-#### D. An example using this function to look at plausibility of observed data:
+### An example using this function to look at plausibility of observed data:
 ```{r}
 plane_diff(location = "12", input = observed_signal, seed = prepped_seed)
 ```
@@ -124,12 +208,12 @@ As was the case above when looking at `plane_score()`, we're comparing a subset 
 
 
 
-## 2. Coverage component, plane_cover():
+# Coverage component, plane_cover():
 
-#### A. Description:
+### Description:
 This function evaluates whether or not the evaluated signal interval covers the last observed value. The interval used in this plausibility component is drawn from the upper and lower bounds of the forecasted prediction interval. As such, **the only accepted signal format is forecast**, which will include upper and lower bounds. The function only uses the 3 arguments mentioned above (location, input, and seed), and again, **input must be a forecast**.
 
-#### B. An example where a flag is NOT raised and the data is plausible:
+### An example where a flag is NOT raised and the data is plausible:
 ```{r}
 # Run plane_cover()
 plane_cover(location = "04", input = forecast_signal, seed = prepped_seed)
@@ -150,7 +234,7 @@ ggplot(data = cover_dat, mapping = aes(x = date, y = flu.admits)) +
 As you can see, the last blue, observed point (34) falls within the prediction interval of the forecast (the translucent red ribbon, between 13 and 103 for the first forecast point).
 
 
-#### C. An example where a flag IS raised and the data is implausible:
+### An example where a flag IS raised and the data is implausible:
 ```{r}
 # Run plane_cover()
 plane_cover(location = "02", input = forecast_signal, seed = prepped_seed)
@@ -175,13 +259,13 @@ As you can see, the last blue, observed point (14) falls outside of the predicti
 
 
 
-## 3.  Taper component, plane_taper():
+#  Taper component, plane_taper():
 
-#### A. Description:
+### Description:
 This function evaluates whether or not the evaluated signal interval tapers (i.e., decreases in width) as horizons progress. The interval used in this plausibility component is drawn from the upper and lower bounds of the forecasted prediction interval. As such, **the only accepted signal format is forecast**, which will include upper and lower bounds. The function only uses the 3 arguments mentioned above (location, input, and seed), and again, **input must be a forecast**.
 
 
-#### B. An example where a flag is NOT raised and the data is plausible:
+### An example where a flag is NOT raised and the data is plausible:
 ```{r}
 # Run plane_taper()
 plane_taper(location = "16", input = forecast_signal, seed = prepped_seed)
@@ -202,7 +286,7 @@ ggplot(data = taper_dat, mapping = aes(x = date, y = flu.admits)) +
 ```
 As you can see, the prediction intervals (translucent red interval around forecast) do not taper; they get wider. In the first forecast point (first horizon), the lower bound of the prediction interval is 0 and the upper is 6, so the width = 6, and that width increases to 7, 8, and 9 as the horizon increases.
 
-#### C. An example where a flag IS raised and the data is implausible:
+### An example where a flag IS raised and the data is implausible:
 None of our forecasts for flu hospital admissions using the HHS Protect data actually have tapering prediction intervals, so we need to create a fake forecast with tapering intervals:
 ```{r}
 # First, create a new forecast signal:
@@ -241,15 +325,15 @@ As you can see, the prediction intervals (translucent red interval around foreca
 
 
 
-## 4. Repeat component, plane_repeat():
+# Repeat component, plane_repeat():
 
-#### A. Description:
+### Description:
 This function evaluates whether consecutive values in observations or forecasts are repeated a k number of times. This function takes in a forecast object that is **either from an observed dataset or forecast dataset**. This function uses the 3 arguments that all rplanes component functions use, and it has two additional arguments:
 
 * `tolerance`: Integer value for the number of allowed repeats before flag is raised. Default is NULL and allowed repeats will be determined from seed by finding the "max repeats" (most repeated values in observed data at location)
 * `prepend`: Integer value for the number of values from seed to add before the evaluated signal. Default is NULL and the number of values will be determined from seed also by using the maximum number of repeats. For example, let's say our seed data is c(1, 2, 3, 3, 3), our forecast is c(3, 3, 5, 6), and our tolerance threshold is set at 4. With a prepend length of 2, the sequence c(3, 3, 3, 3, 5, 6) would be checked for any set of more than 4 consecutive, repeating numbers. In that case, no flag would be raised, because there were only 4 repeating 3's. However, if we change the prepend length to 3, the evaluated sequence would be c(3, 3, 3, 3, 3, 5, 6), and a flag would be raised, because there were more repeats than the tolerance threshold.
 
-#### B. An example where a flag is NOT raised and the data is plausible using default arguments:
+### An example where a flag is NOT raised and the data is plausible using default arguments:
 ```{r}
 plane_repeat(location = "37", input = forecast_signal, seed = prepped_seed, tolerance = NULL, prepend = NULL)
 ```
@@ -267,7 +351,7 @@ ggplot(data = repeat_dat, mapping = aes(x = date, y = flu.admits)) +
 ```
 The forecast doesn't appear to have any repeats, and this is considered a plausible forecast.
 
-#### C. An example where a flag IS raised and the data is implausible using default arguments:
+### An example where a flag IS raised and the data is implausible using default arguments:
 ```{r}
 plane_repeat(location = "32", input = forecast_signal, seed = prepped_seed, tolerance = NULL, prepend = NULL)
 ```
@@ -286,7 +370,7 @@ ggplot(data = repeat_dat_flag, mapping = aes(x = date, y = flu.admits)) +
 ```
 You can see that there are four consecutive repeats in the forecast. This is considered implausible.
 
-#### D. Sensitivity and the tolerance argument:
+### Sensitivity and the tolerance argument:
 We will use the same location as above ("32") where a flag was raised when we used the default tolerance. If we increase the tolerance to 4, you will notice that the flag is no longer raised. Increasing the tolerance reduces the sensitivity of the test.
 ```{r}
 plane_repeat(location = "32", input = forecast_signal, seed = prepped_seed, tolerance = 4, prepend = NULL)
@@ -326,23 +410,23 @@ ggplot(data = repeat_dat_flag, mapping = aes(x = date, y = flu.admits)) +
 The black horizontal line in the plot above is the tolerance length, and you can see that it is shorter than the repeats in the forecast; therefore, a flag has been raised.
 
 
-#### E. An example using this function to look at plausibility of observed data:
+### An example using this function to look at plausibility of observed data:
 ```{r}
 plane_repeat(location = "32", input = observed_signal, seed = prepped_seed)
 ```
 No flag is raised, which indicates that there are not an implausible number of repeats in the observed data.
 
 
-## 5. Trend component, plane_trend():
+# Trend component, plane_trend():
 
-#### A. Description:
+### Description:
 This function identifies any change points in the forecast data or in the final observed data point. Change points are identified by any significant change in magnitude or direction of the slope of the time series. This component can only be used to assess the plausibility of **forecast** data. This function uses the 3 arguments that all rplanes component functions use (location, input, seed), and it has one additional argument:
 
 * `sig_lvl`: The significance level at which to identify change points (between zero and one); default is 0.1
 
 
 
-#### B. An example where a flag is NOT raised and the data is plausible:
+### An example where a flag is NOT raised and the data is plausible:
 ```{r}
 plane_trend(location = "17", input = forecast_signal, seed = prepped_seed)
 ```
@@ -360,7 +444,7 @@ ggplot(data = trend_dat, mapping = aes(x = date, y = flu.admits)) +
 ```
 As we can see, there is no significant change in the magnitude or direction of the slope in the forecast data. This is considered plausible.
 
-#### C. An example where a flag IS raised and the data is implausible:
+### An example where a flag IS raised and the data is implausible:
 ```{r}
 plane_trend(location = "54", input = forecast_signal, seed = prepped_seed)
 ```
@@ -399,7 +483,7 @@ ggplot(data = trend_dat_flag, mapping = aes(x = date, y = flu.admits)) +
 In this plot, both change points are shown with a diamond, but only the latter point is flagged. In this example, the last observed point (blue diamond) was considered the change point. This forecast is implausible.
 
 
-#### D. Sensitivity of the Significance Level:
+### Sensitivity of the Significance Level:
 Let's continue looking at location "54." Under the default significance level (`sig_lvl` = 0.1), a flag is raised and the last observed data point is considered a change point. If we reduce the significance level to 0.05 (and therefore decrease the sensitivity of the test), we now see that no flags are raised:
 ```{r}
 plane_trend(location = "54", input = forecast_signal, seed = prepped_seed, sig_lvl = 0.05)

--- a/vignettes/individual-components.Rmd
+++ b/vignettes/individual-components.Rmd
@@ -1,0 +1,407 @@
+---
+title: "individual-components"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{individual-components}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(rplanes)
+library(dplyr)
+library(purrr)
+library(ggplot2)
+```
+
+
+# Individual Components
+
+The rplanes package currently has a set of 5 components that each test for plausibility in different ways. All 5 components are then wrapped into `plane_score()` to produce an overall score based on the number of components that raised implausibility flags. You can also run the components individually to look at certain aspects of your data. All components can be used to test forecast data, but some cannot be used on observed data. We will go through the components individually below using the same data that we have already read in and formatted in II.1. above. All 5 components use the following arguments, and some have additional arguments:
+
+* `location`: character vector with location code; the location must appear in input and seed. The location can be any character vector with unique names (e.g., FIPS codes, state abbreviations, county names, etc.)
+* `input`: input signal data to be scored; object must be one of signal (forecast or observed - created using `to_signal()`)
+* `seed`: the prepared seed created using `plane_seed()`
+
+Additionally, all components return an `indicator` field that tells us whether or not the data is plausible. If `indicator = TRUE`, the data is implausible and a flag is raised. If it is false, the data is plausible and no flag is raised.
+
+Before we get into the component functions, let's write a function to retrieve the observed and forecast data for a specific location so that we can plot examples of flags of each component:
+```{r}
+get_data <- function(Location) {
+  dat_obs <-
+    observed_signal[["data"]] %>%
+    dplyr::filter(location == Location) %>%
+    dplyr::filter(date <= "2022-10-29") %>%
+    dplyr::mutate(date = as.Date(date)) %>%
+    dplyr::mutate(type = "observed") %>%
+    dplyr::mutate(lower = NA) %>%
+    dplyr::mutate(upper = NA)
+
+
+  dat_fore <-
+    forecast_signal[["data"]] %>%
+    dplyr::select(date, location, flu.admits = point, lower, upper) %>%
+    dplyr::filter(location == Location) %>%
+    dplyr::mutate(type = "forecast")
+
+  dat <- rbind(dat_obs, dat_fore)
+  return(dat)
+}
+```
+
+
+
+
+## 1. Difference component, plane_diff():
+#### A. Description:
+This function implements the point-to-point difference plausibility component. Differences in evaluated signals are calculated from input values iteratively subtracted from the previous values (i.e., for each x at time point i, the difference will be calculated as xi - xi-1). The plausibility analysis uses the evaluated differences to compare against the maximum difference observed and recorded in the seed. This component can be used on either forecast data or observed data, and it only uses the three arguments listed above.
+
+#### B. An example where a flag is NOT raised and the data is plausible:
+First, let's look at a location where the difference component does not raise a flag:
+```{r}
+# Run plane_diff()
+plane_diff(location = "51", input = forecast_signal, seed = prepped_seed)
+```
+The `indicator` at this location is FALSE, meaning that no flag is raised and this seems plausible.
+Also returned are:
+
+* `values`: A vector with the values assessed including the last value in seed concatenated with the evaluated signal values
+* `evaluated_differences`: A vector with the consecutive differences for the values
+* `maximum_difference`: A vector with one value for the maximum difference observed in seed
+
+Let's plot this location to visualize the results:
+```{r fig.align = 'center'}
+# Get data from that location for plotting
+diff_dat <- get_data(Location = "51")  # get observed and forecast data for location "51"
+
+# Plot
+ggplot(data = diff_dat, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Difference Component where Flag Was Not Raised"))
+```
+In this example at location 51, no flag was raised, because the difference between the last observed data point and the first forecast data point (black line, difference = 45) was not greater than the maximum difference between consecutive points within the observed dataset (in this case, that maximum difference is between the second to last observed and the last observed points and it equals 97).
+
+#### C. An example where a flag IS raised and the data is implausible:
+Next, let's look at a location where a flag will be triggered by `plane_diff()`:
+```{r}
+# Run plane_diff()
+plane_diff(location = "09", input = forecast_signal, seed = prepped_seed)
+```
+
+At location "09", the indicator is TRUE and a flag is raised, which means that the data is implausible. The evaluated difference (37) was greater than the maximum difference within the observed dataset (29).
+```{r fig.align = 'center'}
+# Get data from that location for plotting
+diff_dat_flag <- get_data(Location = "09")  # get observed and forecast data for location "09"
+
+# Plot
+ggplot(data = diff_dat_flag, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  geom_vline(xintercept = as.numeric(as.Date("2022-10-29")), linetype = 4, colour = "red") +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Difference Component where Flag Was Raised"))
+```
+
+#### D. An example using this function to look at plausibility of observed data:
+```{r}
+plane_diff(location = "12", input = observed_signal, seed = prepped_seed)
+```
+As was the case above when looking at `plane_score()`, we're comparing a subset of a dataset to the larger version of itself, so the number of flags will naturally be inflated. Nevertheless, the maximum difference within the seed was 144, but in the observed data, we see differences as high as 499, so this example would be flagged as implausible.
+
+
+
+
+## 2. Coverage component, plane_cover():
+
+#### A. Description:
+This function evaluates whether or not the evaluated signal interval covers the last observed value. The interval used in this plausibility component is drawn from the upper and lower bounds of the forecasted prediction interval. As such, **the only accepted signal format is forecast**, which will include upper and lower bounds. The function only uses the 3 arguments mentioned above (location, input, and seed), and again, **input must be a forecast**.
+
+#### B. An example where a flag is NOT raised and the data is plausible:
+```{r}
+# Run plane_cover()
+plane_cover(location = "04", input = forecast_signal, seed = prepped_seed)
+```
+The `indicator` is FALSE, meaning that the forecast is plausible, and the prediction interval (13 - 103) covers the `last_value` (34) of the observed data. Let's confirm this visually:
+```{r fig.align = 'center'}
+cover_dat <- get_data(Location = "04") # get observed and forecast data for location "04"
+
+ggplot(data = cover_dat, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  geom_ribbon(aes(ymin = lower, ymax = upper, colour = type, fill = type), alpha = 0.2) +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Coverage Component where Flag Was Not Raised"))
+```
+As you can see, the last blue, observed point (34) falls within the prediction interval of the forecast (the translucent red ribbon, between 13 and 103 for the first forecast point).
+
+
+#### C. An example where a flag IS raised and the data is implausible:
+```{r}
+# Run plane_cover()
+plane_cover(location = "02", input = forecast_signal, seed = prepped_seed)
+```
+The `indicator` is TRUE, meaning that the forecast is NOT plausible, and the prediction interval (0 - 11) does not cover the `last_value` (14) of the observed data. Let's confirm this visually:
+```{r fig.align = 'center'}
+cover_dat_flag <- get_data(Location = "02") # get observed and forecast data for location "02"
+
+ggplot(data = cover_dat_flag, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  geom_ribbon(aes(ymin = lower, ymax = upper, colour = type, fill = type), alpha = 0.2) +
+  geom_vline(xintercept = as.numeric(as.Date("2022-10-29")), linetype = 4, colour = "red") +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Coverage Component where Flag Was Raised"))
+
+```
+As you can see, the last blue, observed point (14) falls outside of the prediction interval of the forecast (between 0 and 11 for the first forecast point).
+
+
+
+
+## 3.  Taper component, plane_taper():
+
+#### A. Description:
+This function evaluates whether or not the evaluated signal interval tapers (i.e., decreases in width) as horizons progress. The interval used in this plausibility component is drawn from the upper and lower bounds of the forecasted prediction interval. As such, **the only accepted signal format is forecast**, which will include upper and lower bounds. The function only uses the 3 arguments mentioned above (location, input, and seed), and again, **input must be a forecast**.
+
+
+#### B. An example where a flag is NOT raised and the data is plausible:
+```{r}
+# Run plane_taper()
+plane_taper(location = "16", input = forecast_signal, seed = prepped_seed)
+```
+The `indicator` is FALSE, so no flag is raised, and this forecast is considered plausible. The widths of the prediction intervals do not taper; they get larger as the forecast horizon increases (6, 7, 8, 9). Let's visualize this:
+
+```{r fig.align = 'center'}
+taper_dat <- get_data(Location = "16")
+
+ggplot(data = taper_dat, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  geom_ribbon(aes(ymin = lower, ymax = upper, colour = type, fill = type), alpha = 0.2) +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Taper Component where Flag Was Not Raised"))
+```
+As you can see, the prediction intervals (translucent red interval around forecast) do not taper; they get wider. In the first forecast point (first horizon), the lower bound of the prediction interval is 0 and the upper is 6, so the width = 6, and that width increases to 7, 8, and 9 as the horizon increases.
+
+#### C. An example where a flag IS raised and the data is implausible:
+None of our forecasts for flu hospital admissions using the HHS Protect data actually have tapering prediction intervals, so we need to create a fake forecast with tapering intervals:
+```{r}
+# First, create a new forecast signal:
+fake_forecast_signal <- forecast_signal
+
+# Choose a location where you want to change the upper and lower bounds
+# and then find the index where location matches (I picked "23"):
+location_index <- which(fake_forecast_signal$data$location == "23")
+
+# Update the lower and upper values for location "23" so that they taper:
+fake_forecast_signal$data$lower[location_index] <- c(0, 0, 1, 1)
+fake_forecast_signal$data$upper[location_index] <- c(14, 12, 10, 6)
+```
+Now we can run `plane_taper()` using this fake forecast:
+```{r}
+plane_taper(location = "23", input = fake_forecast_signal, seed = prepped_seed)
+```
+The `indicator` is TRUE, so a flag is raised, and this forecast is considered implausible. The widths of the prediction intervals taper; they get smaller as the forecast horizon increases (14, 12, 9, 5). Let's visualize this:
+```{r fig.align = 'center'}
+taper_dat_flag <- get_data(Location = "23")
+# Have to edit this to put fake forecast prediction intervals into this data:
+taper_dat_flag$lower[39:42] <- c(0, 0, 1, 1)
+taper_dat_flag$upper[39:42] <- c(14, 12, 10, 6)
+  
+ggplot(data = taper_dat_flag, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  geom_ribbon(aes(ymin = lower, ymax = upper, colour = type, fill = type), alpha = 0.2) +
+  geom_vline(xintercept = as.numeric(as.Date("2022-10-29")), linetype = 4, colour = "red") +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Taper Component where Flag Was Raised"))
+```
+As you can see, the prediction intervals (translucent red interval around forecast) DO taper. In the first forecast point (first horizon), the lower bound of the prediction interval is 0 and the upper is 14, so the width = 14, and that width decreases to 12, 9, and 5 as the horizon increases. This forecast is implausible.
+
+
+
+## 4. Repeat component, plane_repeat():
+
+#### A. Description:
+This function evaluates whether consecutive values in observations or forecasts are repeated a k number of times. This function takes in a forecast object that is **either from an observed dataset or forecast dataset**. This function uses the 3 arguments that all rplanes component functions use, and it has two additional arguments:
+
+* `tolerance`: Integer value for the number of allowed repeats before flag is raised. Default is NULL and allowed repeats will be determined from seed by finding the "max repeats" (most repeated values in observed data at location)
+* `prepend`: Integer value for the number of values from seed to add before the evaluated signal. Default is NULL and the number of values will be determined from seed also by using the maximum number of repeats. For example, let's say our seed data is c(1, 2, 3, 3, 3), our forecast is c(3, 3, 5, 6), and our tolerance threshold is set at 4. With a prepend length of 2, the sequence c(3, 3, 3, 3, 5, 6) would be checked for any set of more than 4 consecutive, repeating numbers. In that case, no flag would be raised, because there were only 4 repeating 3's. However, if we change the prepend length to 3, the evaluated sequence would be c(3, 3, 3, 3, 3, 5, 6), and a flag would be raised, because there were more repeats than the tolerance threshold.
+
+#### B. An example where a flag is NOT raised and the data is plausible using default arguments:
+```{r}
+plane_repeat(location = "37", input = forecast_signal, seed = prepped_seed, tolerance = NULL, prepend = NULL)
+```
+The `indicator` is FALSE, meaning that no flag is raised and the data is considered plausible. This means that there weren't an unreasonable number of repeats in the forecast (the tolerance default here is calculated as the maximum number of consecutive repeats in the observed data). There were fewer repeats in the forecast than the maximum number of observed repeats. Let's visualize this:
+```{r fig.align = 'center'}
+repeat_dat <- get_data(Location = "37")
+
+ggplot(data = repeat_dat, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Repeat Component where Flag Was Not Raised under Default Arguments"))
+```
+The forecast doesn't appear to have any repeats, and this is considered a plausible forecast.
+
+#### C. An example where a flag IS raised and the data is implausible using default arguments:
+```{r}
+plane_repeat(location = "32", input = forecast_signal, seed = prepped_seed, tolerance = NULL, prepend = NULL)
+```
+The indicator is TRUE, meaning that a flag is raised and the data is implausible. This means that there were an unreasonable number of repeats in the forecast (4 consecutive repeats of 15). There were more repeats in the forecast than the maximum number of observed repeats. Let’s visualize this:
+```{r fig.align = 'center'}
+repeat_dat_flag <- get_data(Location = "32")
+
+ggplot(data = repeat_dat_flag, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  geom_vline(xintercept = as.numeric(as.Date("2022-10-29")), linetype = 4, colour = "red") +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Repeat Component where Flag Was Raised under Default Arguments"))
+```
+You can see that there are four consecutive repeats in the forecast. This is considered implausible.
+
+#### D. Sensitivity and the tolerance argument:
+We will use the same location as above ("32") where a flag was raised when we used the default tolerance. If we increase the tolerance to 4, you will notice that the flag is no longer raised. Increasing the tolerance reduces the sensitivity of the test.
+```{r}
+plane_repeat(location = "32", input = forecast_signal, seed = prepped_seed, tolerance = 4, prepend = NULL)
+```
+
+```{r fig.align = 'center'}
+ggplot(data = repeat_dat_flag, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  geom_segment(aes(x =  as.Date("2022-11-05"), 
+                   y = 24, 
+                   xend = as.Date("2022-11-26"), 
+                   yend = 24)) +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Repeat Component where Flag Was NOT Raised with Increased Tolerance"))
+```
+The black horizontal line in the plot above is the tolerance length, and you can see that it is the same length as the repeats in the forecast; therefore, no flags have been raised. Note that the opposite is also true. If you reduce the tolerance, you increase the sensitivity, and a flag may be raised when it wasn't otherwise:
+```{r}
+plane_repeat(location = "32", input = forecast_signal, seed = prepped_seed, tolerance = 3, prepend = NULL)
+```
+
+```{r fig.align = 'center'}
+ggplot(data = repeat_dat_flag, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  geom_segment(aes(x =  as.Date("2022-11-12"), 
+                   y = 24, 
+                   xend = as.Date("2022-11-26"), 
+                   yend = 24)) +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Repeat Component where Flag Was NOT Raised with Increased Tolerance"))
+```
+The black horizontal line in the plot above is the tolerance length, and you can see that it is shorter than the repeats in the forecast; therefore, a flag has been raised.
+
+
+#### E. An example using this function to look at plausibility of observed data:
+```{r}
+plane_repeat(location = "32", input = observed_signal, seed = prepped_seed)
+```
+No flag is raised, which indicates that there are not an implausible number of repeats in the observed data.
+
+
+## 5. Trend component, plane_trend():
+
+#### A. Description:
+This function identifies any change points in the forecast data or in the final observed data point. Change points are identified by any significant change in magnitude or direction of the slope of the time series. This component can only be used to assess the plausibility of **forecast** data. This function uses the 3 arguments that all rplanes component functions use (location, input, seed), and it has one additional argument:
+
+* `sig_lvl`: The significance level at which to identify change points (between zero and one); default is 0.1
+
+
+
+#### B. An example where a flag is NOT raised and the data is plausible:
+```{r}
+plane_trend(location = "17", input = forecast_signal, seed = prepped_seed)
+```
+The `indicator` is FALSE, so no flag is raised, and this forecast is considered plausible. No change points have been detected in the forecast or in the final observed data point. Because there are no flags, flagged_dates is NA. We will look at the "output" tibble in an example where there were change points, but first, let's observe location 17:
+```{r fig.align = 'center'}
+trend_dat <- get_data(Location = "17")
+
+ggplot(data = trend_dat, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Trend Component where Flag Was Not Raised under Default Arguments"))
+```
+As we can see, there is no significant change in the magnitude or direction of the slope in the forecast data. This is considered plausible.
+
+#### C. An example where a flag IS raised and the data is implausible:
+```{r}
+plane_trend(location = "54", input = forecast_signal, seed = prepped_seed)
+```
+The output of `plane_trend()` is a `list` of 3:
+
+- `indicator`: Logical as to whether or not the any forecast data or the final observed data point are a significant change point
+- `output`: An n x 7 tibble. The length of the forecast plus the observed data determine the length of n. The columns are:
+     - `Location`: A character vector with the location code
+     - `Index`: An integer index of all observed and forecast data
+     - `Date`: The dates corresponding to all observed and forecast data (formatted as date)
+     - `Value`: The incidence of all observed and forecast data (e.g., hospitalization rates)
+     - `Type`: Indicates whether the data row is observed or forecast data
+     - `Changepoint`: Logical identifying any change point (whether in observed or forecast data). A TRUE is returned if any point is determined a change point based on the user defined significance level (sig_lvl).
+     - `Flagged`: Logical indicating whether or not the change point was flagged. Change points are only flagged if they are in the forecast data or are the final observed data point. A TRUE is returned if the Changepoint is TRUE and is a final observed data point or any forecast point.
+ - `flagged_dates`: The date of any flagged change point(s). If there are none, NA is returned
+
+As we see, the indicator was TRUE, so a flag was raised; this forecast is implausible. Notice that two change points were identified (Index 13 and 16), but only one was flagged (Index 16). This is because we are only concerned with change points in the forecast and the last observed data point. Let's visualize this:
+```{r fig.align = 'center'}
+trend_dat_flag <- get_data(Location = "54")
+
+# Get flag info for change points:
+trend_flags <- 
+  plane_trend(location = "54", input = forecast_signal, seed = prepped_seed)[["output"]] %>%
+  dplyr::filter(Changepoint == TRUE)
+
+
+ggplot(data = trend_dat_flag, mapping = aes(x = date, y = flu.admits)) +
+  geom_line() +
+  geom_line(aes(colour = type)) +
+  geom_point(aes(colour = type)) +
+  geom_point(data = trend_flags, mapping = aes(x = Date, y = Value, fill=Flagged), shape=23, size=4) +
+  xlab("Date") +
+  ylab("Flu Hospital Admissions") +
+  ggtitle(paste("Trend Component where Flag Was Raised under Default Arguments"))
+```
+In this plot, both change points are shown with a diamond, but only the latter point is flagged. In this example, the last observed point (blue diamond) was considered the change point. This forecast is implausible.
+
+
+#### D. Sensitivity of the Significance Level:
+Let's continue looking at location "54." Under the default significance level (`sig_lvl` = 0.1), a flag is raised and the last observed data point is considered a change point. If we reduce the significance level to 0.05 (and therefore decrease the sensitivity of the test), we now see that no flags are raised:
+```{r}
+plane_trend(location = "54", input = forecast_signal, seed = prepped_seed, sig_lvl = 0.05)
+```
+Now the `indicator` is FALSE, and no flags are raised. We encourage you to perform some exploratory data analysis on your data to find the level of sensitivity required for your needs.


### PR DESCRIPTION
I understand why we got rid of the specific function arguments in the basic usage vignette, but I'd like to keep them here, because where there are different options (e.g., sig_lvl for trend, and tolderance for repeat), I run through examples where we change those thresholds to show how they are used.