### PR TITLE
control seed without impacting global state

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,19 +1,17 @@
 Package: rplanes
 Title: Plausibility Analysis of Epidemiological Signals
 Version: 0.1.0
-Authors@R: 
-    c(person(given = "VP",
-             family = "Nagraj",
-             role = c("aut", "cre"),
-             email = "nagraj@nagraj.net",
-             comment = c(ORCID = "0000-0003-0060-566X")),
-      person(given = "Desiree",
-             family = "Williams",
-             role = "aut"),
-      person(given = "Amy",
-             family = "Benefield",
-             role = "aut"))
-Description: Provides functionality to prepare data and analyze plausibility of both forecasted and reported epidemiological signals. The functions implement a set of plausibility algorithms that are agnostic to geographic and time resolutions and are calculated independently then presented as a combined score.
+Authors@R: c(
+    person("VP", "Nagraj", , "nagraj@nagraj.net", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0003-0060-566X")),
+    person("Desiree", "Williams", role = "aut"),
+    person("Amy", "Benefield", role = "aut")
+  )
+Description: Provides functionality to prepare data and analyze
+    plausibility of both forecasted and reported epidemiological signals.
+    The functions implement a set of plausibility algorithms that are
+    agnostic to geographic and time resolutions and are calculated
+    independently then presented as a combined score.
 License: MIT + file LICENSE
 URL: https://signaturescience.github.io/rplanes/
 Depends: 
@@ -30,18 +28,19 @@ Imports:
     stringr,
     tibble,
     tidyr,
-    utils
+    utils,
+    withr
 Suggests:
     DT,
     ggplot2,
-    markdown,
     knitr,
+    markdown,
     MMWRweek,
     rmarkdown,
     shiny,
+    shinycssloaders,
     shinyjs,
     shinyWidgets,
-    shinycssloaders,
     testthat (>= 3.0.0),
     tools
 VignetteBuilder: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# rplanes 0.1.1
+
+## Bug fixes
+
+`plane_trend()` no longer sets the seed, but uses [`withr::with_seed()`]
+(https://withr.r-lib.org/reference/with_seed.html) to preserved the global state
 # rplanes 0.1.0
 
 ## New features

--- a/R/planes.R
+++ b/R/planes.R
@@ -371,7 +371,7 @@ plane_repeat <- function(location, input, seed, tolerance = NULL, prepend = NULL
   ## if so ... we cannot fairly say there is a repeat so set to FALSE
   if(length(unique(tmp_seed$all_values)) == 1) {
     ind <- FALSE
-  ## if not ... look at the repeat table to determine if flag is raised
+    ## if not ... look at the repeat table to determine if flag is raised
   } else {
     ## indicator for whether or not the number of rows is > 0
     ## this would indicate that there are repeats
@@ -682,8 +682,12 @@ plane_trend <- function(location, input, seed, sig_lvl = 0.1) {
   ex <- as.matrix(structure(c(tail(obspoint, prepend_length), forepoint))) # We want 4x as much training data as forecast data
 
   # Get break points. When k = NULL, all significant points are picked. Need to play around with the sig.lvl
-  set.seed(123)
-  ecp_output <- ecp::e.divisive(diff(ex), sig.lvl = sig_lvl, k = NULL, min.size = 2)
+  ecp_output <- withr::with_seed(
+    seed = 123,
+    code = {
+      ecp::e.divisive(diff(ex), sig.lvl = sig_lvl, k = NULL, min.size = 2)
+    }
+  )
   # We use diff(ex) instead of the raw data, which is a preference and slightly changes the way the points are identified. When we use diff(ex), the index aligns with the gap between points rather than the points themselves. Instead of identifying a change point based on the change in size between two points, it identifies change points based on the change in the change itself. For example, the dataframe below shows an example of ex and diff(ex):
   # ex diff.ex.
   # 1  3        6


### PR DESCRIPTION
fix #149 

 * Use `withr::set_seed()` to avoid changing the state of the global environment
 * run `usethis::use_tidy_description()` to format DESCRIPTION